### PR TITLE
FIX: use Dataset(default_union=True) for Turtle serialization

### DIFF
--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -15,8 +15,10 @@ from collections import namedtuple
 from pyld import jsonld
 try:
 	from rdflib import Dataset as CG
+	_CG_KWARGS = {"default_union": True}
 except:
 	from rdflib import ConjunctiveGraph as CG
+	_CG_KWARGS = {}
 
 KEY_ORDER_DEFAULT = 10000
 LINKED_ART_CONTEXT_URI = "https://linked.art/ns/v1/linked-art.json"
@@ -498,7 +500,7 @@ class CromulentFactory(object):
 			return data
 		else:
 			# Need to pass over to rdflib
-			g = CG()
+			g = CG(**_CG_KWARGS)
 			for (k,v) in min_context.items():
 				if v[0] != "@":
 					g.bind(k, v)


### PR DESCRIPTION
Fixes #58 

The changed behavior mentioned in https://github.com/linked-art/linked.art/issues/760 was introduced in 1c1ea0445b5d4a829f83e388cf97ac0a6315735d,  but really that's because the semantics of turtle serialization differs between `rdflib.ConjunctiveGraph` and `rdflib.Dataset`!

 AFAICT `Dataset.serialize("turtle")` only emits triples from the default graph, which is empty in our case (all triples live in a named graph). As a result, Crom started producing empty TTL outputs (just `"\n"`), which in turn broke the Linked.Art `"Turtle (raw)"` examples.

MWE:

```python
from rdflib import ConjunctiveGraph, Dataset

DATA = (
    "<http://example.org/subject> "
    "<http://example.org/predicate> "
    "<http://example.org/object> "
    "<http://example.org/graph> .\n"
)

ds = Dataset(default_union=True)  # <- THIS IS THE FIX
cg = ConjunctiveGraph()

cg.parse(data=DATA, format="nquads")
cg_ttl_out = cg.serialize(format="ttl")
print(f"ConjunctiveGraph TTL Output:\n{cg_ttl_out}")

ds.parse(data=DATA, format="nquads")
ds_ttl_out = ds.serialize(format="ttl")
print(f"Dataset TTL Output:\n{ds_ttl_out}")

assert ds_ttl_out == cg_ttl_out
```